### PR TITLE
fix(ci): skip Docker Build when AWS credentials not configured

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -13,8 +13,26 @@ env:
   ECR_REGISTRY: ${{ vars.ECR_REGISTRY }}
 
 jobs:
+  # Pre-flight: check if AWS credentials are configured
+  check-credentials:
+    runs-on: ubuntu-latest
+    outputs:
+      has-aws: ${{ steps.check.outputs.has-aws }}
+    steps:
+      - name: Check AWS configuration
+        id: check
+        run: |
+          if [ -n "${{ vars.AWS_ROLE_ARN }}" ] && [ -n "${{ vars.ECR_REGISTRY }}" ]; then
+            echo "has-aws=true" >> $GITHUB_OUTPUT
+          else
+            echo "has-aws=false" >> $GITHUB_OUTPUT
+            echo "::warning::Skipping Docker build - AWS_ROLE_ARN and ECR_REGISTRY not configured in repository variables"
+          fi
+
   # Detect changed services
   changes:
+    needs: check-credentials
+    if: needs.check-credentials.outputs.has-aws == 'true'
     runs-on: ubuntu-latest
     outputs:
       services: ${{ steps.detect.outputs.services }}


### PR DESCRIPTION
## Summary
- Docker Build & Push workflow가 AWS 자격 증명 없이 매 main push마다 실패하는 문제 수정
- `check-credentials` job 추가: `AWS_ROLE_ARN`과 `ECR_REGISTRY` repository variable이 설정되지 않으면 전체 빌드를 gracefully 건너뜀
- 자격 증명 미설정 시 warning 메시지 출력 후 성공으로 종료

## Root Cause
```
##[error]Credentials could not be loaded, please check your action inputs:
Could not load credentials from any providers
```
`vars.AWS_ROLE_ARN`과 `vars.ECR_REGISTRY`가 GitHub repository variables에 설정되지 않아 `aws-actions/configure-aws-credentials@v4`에서 실패

## Test plan
- [ ] AWS 자격 증명 없는 상태에서 main push → 워크플로우 성공 (skip)
- [ ] AWS 자격 증명 설정 후 main push → 정상 빌드 & push

🤖 Generated with [Claude Code](https://claude.com/claude-code)