### PR TITLE
fix(ci): skip Istio/Kiali CRDs in kubeconform validation

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -111,6 +111,7 @@ jobs:
         run: |
           kubeconform -summary -strict \
             -ignore-filename-pattern 'tls-certificate.yaml' \
+            -skip 'IstioOperator,Kiali' \
             -schema-location default \
             -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
             infra/k8s/


### PR DESCRIPTION
## Summary
- Skip `IstioOperator` and `Kiali` custom resource kinds in kubeconform validation
- These CRDs have no schema in the datreeio/CRDs-catalog, causing `k8s-validate` job failures since PR #41

## Root Cause
```
infra/k8s/istio/istio-operator.yaml - IstioOperator failed validation: could not find schema
infra/k8s/istio/kiali.yaml - Kiali failed validation: could not find schema
```

## Test plan
- [ ] `k8s-validate` job passes (118 valid + 2 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)