### PR TITLE
feat(argocd): ApplicationSet multi-environment deployment

### DIFF
--- a/infra/argocd/applicationset.yaml
+++ b/infra/argocd/applicationset.yaml
@@ -1,0 +1,65 @@
+# ApplicationSet: multi-environment deployment from single template
+# Generates ArgoCD Applications for dev/staging/prod from one definition
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: sportstix-services
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - list:
+        elements:
+          - env: dev
+            namespace: sportstix-dev
+            targetRevision: develop
+            autoSync: true
+            replicas: "1"
+          - env: staging
+            namespace: sportstix-staging
+            targetRevision: main
+            autoSync: true
+            replicas: "2"
+          - env: prod
+            namespace: sportstix
+            targetRevision: main
+            autoSync: false
+            replicas: "2"
+  template:
+    metadata:
+      name: "sportstix-{{.env}}"
+      namespace: argocd
+      labels:
+        app.kubernetes.io/part-of: sportstix
+        sportstix.io/env: "{{.env}}"
+    spec:
+      project: sportstix
+      source:
+        repoURL: https://github.com/ressKim-io/ticket-traffic.git
+        targetRevision: "{{.targetRevision}}"
+        path: infra/k8s
+        directory:
+          recurse: true
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: "{{.namespace}}"
+      syncPolicy:
+        syncOptions:
+          - CreateNamespace=true
+          - PrunePropagationPolicy=foreground
+          - PruneLast=true
+        retry:
+          limit: 3
+          backoff:
+            duration: 5s
+            factor: 2
+            maxDuration: 1m
+  templatePatch: |
+    {{- if eq .autoSync "true" }}
+    spec:
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+    {{- end }}

--- a/infra/argocd/project.yaml
+++ b/infra/argocd/project.yaml
@@ -14,6 +14,10 @@ spec:
   destinations:
     - namespace: sportstix
       server: https://kubernetes.default.svc
+    - namespace: sportstix-dev
+      server: https://kubernetes.default.svc
+    - namespace: sportstix-staging
+      server: https://kubernetes.default.svc
     - namespace: kyverno
       server: https://kubernetes.default.svc
     - namespace: external-secrets


### PR DESCRIPTION
## Summary
- Add ApplicationSet for dev/staging/prod multi-environment deployment
- dev: develop branch, auto-sync | staging: main, auto-sync | prod: main, manual sync
- Add sportstix-dev/staging namespace destinations to AppProject
- Uses goTemplate with templatePatch for conditional autoSync

## Test plan
- [ ] ApplicationSet YAML valid (goTemplate syntax)
- [ ] AppProject destinations include all environment namespaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)