### PR TITLE
feat(k8s): cert-manager TLS automation with Let's Encrypt

### DIFF
--- a/infra/argocd/cert-manager.yaml
+++ b/infra/argocd/cert-manager.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager
+  namespace: argocd
+spec:
+  project: sportstix
+  source:
+    repoURL: https://charts.jetstack.io
+    chart: cert-manager
+    targetRevision: v1.16.3
+    helm:
+      releaseName: cert-manager
+      values: |
+        installCRDs: true
+        replicaCount: 1
+        prometheus:
+          enabled: true
+          servicemonitor:
+            enabled: true
+            namespace: observability
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cert-manager
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/infra/argocd/project.yaml
+++ b/infra/argocd/project.yaml
@@ -11,6 +11,7 @@ spec:
     - 'https://kedacore.github.io/charts'
     - 'https://vmware-tanzu.github.io/helm-charts'
     - 'https://charts.chaos-mesh.org'
+    - 'https://charts.jetstack.io'
   destinations:
     - namespace: sportstix
       server: https://kubernetes.default.svc
@@ -30,6 +31,8 @@ spec:
       server: https://kubernetes.default.svc
     - namespace: chaos-mesh
       server: https://kubernetes.default.svc
+    - namespace: cert-manager
+      server: https://kubernetes.default.svc
   clusterResourceWhitelist:
     - group: ''
       kind: Namespace
@@ -37,6 +40,8 @@ spec:
       kind: ClusterPolicy
     - group: external-secrets.io
       kind: ClusterSecretStore
+    - group: cert-manager.io
+      kind: ClusterIssuer
   namespaceResourceWhitelist:
     - group: '*'
       kind: '*'

--- a/infra/k8s/ingress/tls-certificate.yaml
+++ b/infra/k8s/ingress/tls-certificate.yaml
@@ -1,10 +1,4 @@
-# TLS certificate placeholder
-# In production, use cert-manager with Let's Encrypt:
-#   kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.0/cert-manager.yaml
-#
-# Then create a ClusterIssuer and Certificate resource instead of manual Secret.
-# This file serves as documentation for the expected Secret format.
----
+# cert-manager ClusterIssuer for Let's Encrypt production
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
@@ -20,6 +14,24 @@ spec:
           ingress:
             ingressClassName: nginx
 ---
+# cert-manager ClusterIssuer for Let's Encrypt staging (testing)
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: admin@sportstix.io
+    privateKeySecretRef:
+      name: letsencrypt-staging-key
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: nginx
+---
+# TLS Certificate for sportstix domains
+# cert-manager auto-creates and renews the sportstix-tls Secret
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -33,3 +45,5 @@ spec:
   dnsNames:
     - sportstix.io
     - api.sportstix.io
+  duration: 2160h
+  renewBefore: 360h


### PR DESCRIPTION
## Summary
- Deploy cert-manager v1.16.3 via ArgoCD with Prometheus ServiceMonitor
- Add letsencrypt-prod and letsencrypt-staging ClusterIssuers (HTTP-01 solver)
- Certificate for sportstix.io + api.sportstix.io (90d duration, auto-renew at 15d)
- AppProject: jetstack chart repo, cert-manager namespace, ClusterIssuer whitelist

## Test plan
- [ ] tls-certificate.yaml ignored by kubeconform (existing pattern)
- [ ] Ingress references sportstix-tls Secret (matches Certificate secretName)

🤖 Generated with [Claude Code](https://claude.com/claude-code)