### PR TITLE
feat(k8s): OpenCost FinOps cost allocation

### DIFF
--- a/infra/argocd/opencost.yaml
+++ b/infra/argocd/opencost.yaml
@@ -1,0 +1,37 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: opencost
+  namespace: argocd
+spec:
+  project: sportstix
+  source:
+    repoURL: https://opencost.github.io/opencost-helm-chart
+    chart: opencost
+    targetRevision: 1.43.2
+    helm:
+      releaseName: opencost
+      values: |
+        opencost:
+          exporter:
+            defaultClusterId: sportstix-prod
+          prometheus:
+            internal:
+              serviceName: prometheus
+              namespaceName: observability
+              port: 9090
+          ui:
+            enabled: true
+          metrics:
+            serviceMonitor:
+              enabled: true
+              namespace: observability
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: opencost
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/infra/argocd/project.yaml
+++ b/infra/argocd/project.yaml
@@ -13,6 +13,7 @@ spec:
     - 'https://charts.chaos-mesh.org'
     - 'https://charts.jetstack.io'
     - 'https://falcosecurity.github.io/charts'
+    - 'https://opencost.github.io/opencost-helm-chart'
   destinations:
     - namespace: sportstix
       server: https://kubernetes.default.svc
@@ -35,6 +36,8 @@ spec:
     - namespace: cert-manager
       server: https://kubernetes.default.svc
     - namespace: falco
+      server: https://kubernetes.default.svc
+    - namespace: opencost
       server: https://kubernetes.default.svc
   clusterResourceWhitelist:
     - group: ''


### PR DESCRIPTION
## Summary
- OpenCost v1.43.2 ArgoCD Helm Application 배포
- Prometheus 연동으로 클러스터/네임스페이스/서비스별 비용 분석
- ServiceMonitor로 observability 스택 통합
- ArgoCD project에 opencost sourceRepo + namespace 추가

## Changes
- `infra/argocd/opencost.yaml` — OpenCost Helm chart Application
- `infra/argocd/project.yaml` — sourceRepos, destinations 추가

## Test plan
- [ ] ArgoCD Application sync 확인
- [ ] OpenCost UI 접근 확인 (port-forward)
- [ ] Prometheus 메트릭 수집 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)